### PR TITLE
fix: /usr/local/bin/docker-entrypoint.sh: line 6: [!: command not found

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -eu
 
 /usr/bin/vpnd 2>&1
 
-if [! -f /var/lock/subsys/local ]; then
+if [ ! -f /var/lock/subsys/local ]; then
   touch /var/lock/subsys/local
 fi
 


### PR DESCRIPTION
docker run時に出力されたエラーに対応